### PR TITLE
Update query BNF

### DIFF
--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -145,7 +145,7 @@ Strategy queries allow store, load, reuse and refine the strategies by assigning
 StrategyQuery ::=
 	    'strategy' Name '=' Query [ 'under' Name ]
 	  | 'saveStrategy' '(' Path ',' Name ')'
-	  | 'loadStrategy' Features '(' Path ')'
+	  | 'strategy' Name '=' 'loadStrategy' Features '(' Path ')'
 
 Query ::=
         SymbQuery

--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -53,9 +53,9 @@ Controller synthesis queries are decided using symbolic techniques over Timed Ga
 
 ``` EBNF
 TIGAQuery ::=
-        'control:' Goal
-      | 'E<>' 'control:' Goal
-      | '{' someting '}' 'control:' Goal
+        'control:' Goal Subjection
+      | 'E<>' 'control:' Goal Subjection
+      | '{' someting '}' 'control:' Goal Subjection
       | TimeEfficientGameQuery Goal
 
 TimeEfficientGameQuery ::=
@@ -76,6 +76,10 @@ NotLooseExpression ::= Expression
 u ::= Expression
 
 g ::= Expression
+
+Subjection ::= 
+	    // empty for no subjection
+	  | under Name   
 ```
 
 <dl>
@@ -84,6 +88,9 @@ g ::= Expression
 
 <dt><tt>g</tt></dt>
 <dd>describes an additional time limit such that the game can be won within <tt>u</tt> - <tt>g</tt> time units.</dd>
+
+<dt><tt>Subjection</tt></dt>
+<dd>indicates whether the query should be subjected to a strategy.</dd>
 </dl>
 
 
@@ -147,15 +154,19 @@ All expressions are state predicates and must be side effect free. It is possibl
 
 ``` EBNF
 LearningQuery ::=
-        ExpQuantifier '(' Expression ')' '[' BoundType ']' Features ':' PathType Expression
-	  | ExpQuantifier '[' BoundType ']' Features ':' PathType Expression
-	  | ExpPrQuantifier '[' BoundType ']' Features ':' PathType Expression
+        ExpQuantifier '(' Expression ')' '[' BoundType ']' Features ':' PathType Expression Subjection
+	  | ExpQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection
+	  | ExpPrQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection
 
 ExpQuantifier ::= ( minE | maxE )
 
 ExpPrQuantifier ::= ( minPr | maxPr )
 
-Features ::= '{' List '}' '->' '{' List '}'   
+Features ::= '{' List '}' '->' '{' List '}' 
+
+Subjection ::= 
+	    // empty for no subjection
+	  | under Name   
 ```
 
 <dl>
@@ -164,6 +175,9 @@ Features ::= '{' List '}' '->' '{' List '}'
 
 <dt><tt>Name</tt></dt>
 <dd>indicates the name of a strategy, see also next section.</dd>
+
+<dt><tt>Subjection</tt></dt>
+<dd>indicates whether the query should be subjected to a strategy.</dd>
 </dl>
 
 
@@ -183,17 +197,10 @@ AssignableQuery ::=
 NonAssignableQuery ::=
         SymbQuery
 	  | SMCQuery
-	  | 'saveStrategy' '(' Path ',' Name ')'
-
-Subjection ::= 
-	    // empty for no subjection
-	  | under Name  
+	  | 'saveStrategy' '(' Path ',' Name ')' 
 ```
 
 <dl>
-<dt><tt>Subjections</tt></dt>
-<dd>indicates whether the query should be subjected to a strategy.</dd>
-
 <dt><tt>Name</tt></dt>
 <dd>indicates the name of a strategy.</dd>
 

--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -124,16 +124,30 @@ All expressions are state predicates and must be side effect free. It is possibl
 
 ``` EBNF
 LearningQuery ::=
-     ExpQuantifier '(' Expression ')' '[' BoundType ']' Features ':' PathType Expression
+        ExpQuantifier '(' Expression ')' '[' BoundType ']' Features ':' PathType Expression Subjection
+	  | ExpQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection
+	  | ExpPrQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection
 
-ExpQuantifier ::= ( min | max )
+ExpQuantifier ::= ( minE | maxE )
+
+ExpPrQuantifier ::= ( minPr | maxPr )
 
 Features ::= '{' List '}' '->' '{' List '}'
+
+Subjection ::= 
+	    // empty for no subjection
+	  | under Name     
 ```
 
 <dl>
 <dt><tt>Features</tt></dt>
 <dd>describes a mapping from partial state to .</dd>
+
+<dt><tt>Subjections</tt></dt>
+<dd>indicates whether the query should be subjected to a strategy.</dd>
+
+<dt><tt>Name</tt></dt>
+<dd>indicates the name of a strategy, see also next section.</dd>
 </dl>
 
 

--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -113,14 +113,14 @@ SMCQuery ::=
       | Probability Subjection
       | ProbUntil Subjection
       | Probability ( '<=' | '>=' ) PROB Subjection
-      | Probability ( '<=' | '>=' ) Probability Subjection
+      | Probability '>=' Probability Subjection
       | Estimate Subjection
 
-Simulate ::= 'simulate' SIMRUNS '[' SMCBounds ']' '{' List '}' [ : Expression [ ':' SATRUNS ]]
+Simulate ::= 'simulate' SIMRUNS '[' BoundType ']' '{' List '}' [ : Expression [ ':' SATRUNS ]]
 
 Probability ::= 
         'Pr' Expression
-      | 'Pr[' SMCBounds ']' '(' PathType Expression ')'
+      | 'Pr[' BoundType ']' '(' PathType Expression ')'
 
 ProbUntil   ::= 'Pr[' SMCBounds ']' '(' Expression 'U' Expression ')'
 

--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -12,19 +12,23 @@ Symbolic queries are performed using symbolic operations based on symbolic seman
 
 ``` EBNF
 SymbQuery ::=
-        'A[]' Expression
-      | 'E<>' Expression
-      | 'E[]' Expression
-      | 'A<>' Expression
-      | Expression --> Expression
+        'A[]' Expression Subjection
+      | 'E<>' Expression Subjection
+      | 'E[]' Expression Subjection
+      | 'A<>' Expression Subjection
+      | Expression --> Expression Subjection
 
-      | 'sup' ':' List
-      | 'sup' '{' Expression '}' ':' List
+      | 'sup' ':' List Subjection
+      | 'sup' '{' Expression '}' ':' List Subjection
 
-      | 'inf' ':' List
-      | 'inf' '{' Expression '}' ':' List
+      | 'inf' ':' List Subjection
+      | 'inf' '{' Expression '}' ':' List Subjection
 
 List ::= Expression | Expression ',' List
+
+Subjection ::= 
+	    // empty for no subjection
+	  | under Name   
 ```
 
 For <tt>sup</tt> properties, expression may not contain clock constraints and must evaluate to either an integer or a clock.
@@ -46,6 +50,11 @@ For <tt>sup</tt> properties, expression may not contain clock constraints and mu
 *   <tt>sup{expression}: list</tt>
     The expressions in the list are evaluated only on the states that satisfy the the expression (a state predicate) that acts like an observation.
 *   The <tt>inf</tt> formula are similar to <tt>sup</tt> but for infima. A state predicate should be used when a clock infimum is asked otherwise the trivial result is >= 0.
+
+<dl>
+<dt><tt>Subjection</tt></dt>
+<dd>indicates whether the query should be subjected to a strategy.</dd>
+</dl>
 
 ## Controller Synthesis Queries
 
@@ -100,16 +109,18 @@ Statistical queries are decided using concrete semantics of stochastic hybrid au
 
 ``` EBNF
 SMCQuery ::=
-	    Simulate
-      | Probability
-      | ProbUntil
-      | Probability ( '<=' | '>=' ) PROB
-      | Probability ( '<=' | '>=' ) Probability
-      | Estimate
+	    Simulate Subjection
+      | Probability Subjection
+      | ProbUntil Subjection
+      | Probability ( '<=' | '>=' ) PROB Subjection
+      | Probability ( '<=' | '>=' ) Probability Subjection
+      | Estimate Subjection
 
-Simulate ::= 'simulate' '[' SMCBounds ']' '{' List '}' [ : Expression [ ':' SATRUNS ]]
+Simulate ::= 'simulate' SIMRUNS '[' SMCBounds ']' '{' List '}' [ : Expression [ ':' SATRUNS ]]
 
-Probability ::= 'Pr[' SMCBounds ']' '(' PathType Expression ')'
+Probability ::= 
+        'Pr' Expression
+      | 'Pr[' SMCBounds ']' '(' PathType Expression ')'
 
 ProbUntil   ::= 'Pr[' SMCBounds ']' '(' Expression 'U' Expression ')'
 
@@ -120,6 +131,10 @@ SMCBounds ::= BoundType [ ; RUNS ]
 BoundType ::= (  | Clock | '#' ) '<=' BOUND
 
 PathType ::= ( '<>' | '[]' )
+
+Subjection ::= 
+	    // empty for no subjection
+	  | under Name   
 ```
 
 <dl>
@@ -132,6 +147,9 @@ PathType ::= ( '<>' | '[]' )
 <dt><tt>SATRUNS</tt></dt>
 <dd>is an optional positive integer constant denoting the maximum number of runs that satisfy the state expression.</dd>
 
+<dt><tt>SATRUNS</tt></dt>
+<dd>is a positive integer constant denoting the number of simulated runs.</dd>
+
 <dt><tt>PROB</tt></dt>
 <dd>is a floating point number from an interval [0;1] denoting a probability bound.</dd>
 
@@ -143,6 +161,9 @@ PathType ::= ( '<>' | '[]' )
 
 <dt><tt>'max:'</tt></dt>
 <dd>means the maximum value over a run of the proceeding expression.</dd>
+
+<dt><tt>Subjection</tt></dt>
+<dd>indicates whether the query should be subjected to a strategy.</dd>
 </dl>
 
 All expressions are state predicates and must be side effect free. It is possible to test whether a certain process is in a given location using expressions on the form <tt>process.location</tt>.

--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -212,7 +212,7 @@ AssignQuery ::=
 
 AssignableQuery ::=
         TIGAQuery
-	  | LearningQuery Subjection
+	  | LearningQuery
 	  | 'loadStrategy' Features '(' Path ')'
 
 NonAssignableQuery ::=

--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -113,7 +113,7 @@ SMCQuery ::=
       | Probability Subjection
       | ProbUntil Subjection
       | Probability ( '<=' | '>=' ) PROB Subjection
-      | Probability '>=' Probability Subjection
+      | Probability Subjection '>=' Probability Subjection
       | Estimate Subjection
 
 Simulate ::= 'simulate' SIMRUNS '[' BoundType ']' '{' List '}' [ : Expression [ ':' SATRUNS ]]

--- a/content/language-reference/requirements-specification/_index.md
+++ b/content/language-reference/requirements-specification/_index.md
@@ -53,15 +53,38 @@ Controller synthesis queries are decided using symbolic techniques over Timed Ga
 
 ``` EBNF
 TIGAQuery ::=
-        'control:' 'A<>' WinExpression
-      | 'control:' 'A[' NotLooseExpression 'U' WinExpression ']'
-	  | 'control:' 'A[' NotLooseExpression 'W' WinExpression ']'
-      | 'control:' 'A[' NotLooseExpression ']'
+        'control:' Goal
+      | 'E<>' 'control:' Goal
+      | '{' someting '}' 'control:' Goal
+      | TimeEfficientGameQuery Goal
+
+TimeEfficientGameQuery ::=
+        'control_t*' '(' u ',' g '):'
+      | 'control_t*' '(' u '):'
+      | 'control_t*:'
+      
+Goal ::=  
+         'A<>' WinExpression
+      | 'A[' NotLooseExpression 'U' WinExpression ']'
+      | 'A[' NotLooseExpression 'W' WinExpression ']'
+      | 'A[' NotLooseExpression ']'
 
 WinExpression ::= Expression
 
 NotLooseExpression ::= Expression
+
+u ::= Expression
+
+g ::= Expression
 ```
+
+<dl>
+<dt><tt>u</tt></dt>
+<dd>describes a time limit within the game must be won.</dd>
+
+<dt><tt>g</tt></dt>
+<dd>describes an additional time limit such that the game can be won within <tt>u</tt> - <tt>g</tt> time units.</dd>
+</dl>
 
 
 ## Statistical Queries
@@ -70,7 +93,7 @@ Statistical queries are decided using concrete semantics of stochastic hybrid au
 
 ``` EBNF
 SMCQuery ::=
-	  | Simulate
+	    Simulate
       | Probability
       | ProbUntil
       | Probability ( '<=' | '>=' ) PROB
@@ -124,27 +147,20 @@ All expressions are state predicates and must be side effect free. It is possibl
 
 ``` EBNF
 LearningQuery ::=
-        ExpQuantifier '(' Expression ')' '[' BoundType ']' Features ':' PathType Expression Subjection
-	  | ExpQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection
-	  | ExpPrQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection
+        ExpQuantifier '(' Expression ')' '[' BoundType ']' Features ':' PathType Expression
+	  | ExpQuantifier '[' BoundType ']' Features ':' PathType Expression
+	  | ExpPrQuantifier '[' BoundType ']' Features ':' PathType Expression
 
 ExpQuantifier ::= ( minE | maxE )
 
 ExpPrQuantifier ::= ( minPr | maxPr )
 
-Features ::= '{' List '}' '->' '{' List '}'
-
-Subjection ::= 
-	    // empty for no subjection
-	  | under Name     
+Features ::= '{' List '}' '->' '{' List '}'   
 ```
 
 <dl>
 <dt><tt>Features</tt></dt>
 <dd>describes a mapping from partial state to .</dd>
-
-<dt><tt>Subjections</tt></dt>
-<dd>indicates whether the query should be subjected to a strategy.</dd>
 
 <dt><tt>Name</tt></dt>
 <dd>indicates the name of a strategy, see also next section.</dd>
@@ -156,20 +172,31 @@ Subjection ::=
 Strategy queries allow store, load, reuse and refine the strategies by assigning names to them.
 
 ``` EBNF
-StrategyQuery ::=
-	    'strategy' Name '=' Query [ 'under' Name ]
-	  | 'saveStrategy' '(' Path ',' Name ')'
-	  | 'strategy' Name '=' 'loadStrategy' Features '(' Path ')'
+AssignQuery ::=
+	    'strategy' Name '=' AssignableQuery
 
-Query ::=
+AssignableQuery ::=
+        TIGAQuery
+	  | LearningQuery Subjection
+	  | 'loadStrategy' Features '(' Path ')'
+
+NonAssignableQuery ::=
         SymbQuery
-	  | TIGAQuery
 	  | SMCQuery
-	  | LearningQuery
+	  | 'saveStrategy' '(' Path ',' Name ')'
 
+Subjection ::= 
+	    // empty for no subjection
+	  | under Name  
 ```
 
 <dl>
+<dt><tt>Subjections</tt></dt>
+<dd>indicates whether the query should be subjected to a strategy.</dd>
+
+<dt><tt>Name</tt></dt>
+<dd>indicates the name of a strategy.</dd>
+
 <dt><tt>Path</tt></dt>
 <dd>is a double-quoted character sequence (string) denoting a file system path.</dd>
 </dl>

--- a/content/language-reference/requirements-specification/smc_queries.md
+++ b/content/language-reference/requirements-specification/smc_queries.md
@@ -8,17 +8,15 @@ UPPAAL can estimate the probability of expression values statistically. There ar
 
 ## Simulation
 
-<tt>'simulate' '[' SMCBounds ']' '{' List '}' [ : Expression [ ':' SATRUNS ]]</tt>
-
-<tt>SMCBounds ::= BoundType [ ; RUNS ]</tt>
+<tt>'simulate' SIMRUNS '[' BoundType ']' '{' List '}' [ : Expression [ ':' SATRUNS ]]</tt>
 
 <tt>BoundType ::= (  | Clock | '#' ) '<=' BOUND</tt>
 
-The simulation query collects the valuation of the specified list of expressions over the time, cost or action-transitions of the simulated run. The simulation runs can be filtered by a state expression after the colon (<tt>':'</tt>) and the number of satisfying runs can be limited by positive integer <tt>SATRUNS</tt>. If the filtering expression is provided then the result also includes a probability confidence interval similar to Probability Estimation below.
+The simulation query collects the valuation of the specified list of expressions over the time, cost or action-transitions of the simulated run. The simulation runs can be filtered by a state expression after the colon (<tt>':'</tt>) and the number of satisfying runs can be limited by positive integer <tt> SIMRUNS </tt>. If the filtering expression is provided then the result also includes a probability confidence interval similar to Probability Estimation below.
 
 ## Probability Estimation (Quantitative Model Checking)
 
-<tt>'Pr[' SMCBounds '](' ('<>' | '[]') Expression ')'</tt>
+<tt>'Pr[' BoundType '](' ('<>' | '[]') Expression ')'</tt>
 
 Quantitative query estimates the probability of a path expression being true given that the predicate in probability brackets is true. Intuitively the model exploration is bounded by an expression in the brackets: it can be limited by setting the bound on absolute model time, a clock value, or the number of steps (discrete transitions).
 
@@ -36,7 +34,7 @@ Hypothesis testing checks whether the probability of a property is less or great
 
 ## Probability Comparison
 
-<tt>'Pr[' SMCBounds '](' ('<>' | '[]') Expression ')' **('<='|'>=')** 'Pr[' ( Variable | '#' ) '<=' CONST '](' ('<>' | '[]') Expression ')'</tt>
+<tt>'Pr[' SMCBounds '](' ('<>' | '[]') Expression ')' **'>='** 'Pr[' ( Variable | '#' ) '<=' CONST '](' ('<>' | '[]') Expression ')'</tt>
 
 Compares two probabilities indirectly without estimating them.
 


### PR DESCRIPTION
The BNFs of the different types of queries (https://docs.uppaal.org/language-reference/requirements-specification/) were not reflecting accurately what is and is not accepted by the parser.

Using `parser.y` I have updated the BNFs to reflect what is possible.

Two points are open that need to be resolved before we can actually merge it:
1. The syntax of partially observable TIGA-based queries is unclear. In the parser it is defined as `'{' ExpressionList '}' 'control:' Goal Subjection`, but when I try to run this query I get an error message stating "Clock lower bound must be weak and upper bound strict.", so not any `ExpressionList` is accepted. It would be useful to state these additional restrictions here in the documentation, but I don't know what they are.
2. Almost all queries can be subjected to a strategy *except* a `TimeEfficientGameQuery` query. Therefore, individual queries have `Subjection` instead of query categories in general. This leads to a lot of `Subjections` scattered around. Any suggestion for a better way to notate this is welcome.