### PR TITLE
Add trace file extensions to documentation

### DIFF
--- a/content/gui-reference/Symbolic-Simulator/simulation-control.md
+++ b/content/gui-reference/Symbolic-Simulator/simulation-control.md
@@ -15,7 +15,7 @@ The six buttons below the trace view have the following semantics:
 *   **Next:** highlights the element immediately following the current selection (if any) in the trace.
 *   **Replay:** replays the trace starting from the currently selected element.
 *   **Open:** opens a file dialog for loading a trace from file.
-*   **Save:** opens a file dialog for saving the current trace on file.
+*   **Save:** opens a file dialog for saving the current trace on file. The valid file extension is "xtr". When no file extension is provided, it will be automatically appended.
 *   **Random:** starts a random simulation where the simulator proceed automatically by randomly selecting enabled transitions.
 
 The slider at the bottom of the control panel is used to control the speed used when traces are replayed and when random simulation is performed.

--- a/content/gui-reference/concrete-simulator/simulation-control.md
+++ b/content/gui-reference/concrete-simulator/simulation-control.md
@@ -16,6 +16,8 @@ The _Simulation Trace_ area contains a combo box that displays the current time 
 *   **Prev:** highlights the element immediately preceding the current selection (if any) in the trace.
 *   **Next:** highlights the element immediately following the current selection (if any) in the trace.
 *   **Play:** replays the trace starting from the currently selected element.
+*   **Open:** opens a file dialog for loading a trace from file.
+*   **Save:** opens a file dialog for saving the current trace on file. The valid file extension is "uctr". When no file extension is provided, it will be automatically appended.
 *   **Random:** starts a random simulation where the simulator proceed automatically by randomly selecting enabled transitions at random time.
 
 The slider is used to control the speed used when traces are replayed and when random simulation is performed.


### PR DESCRIPTION
Also adds the description of the Open button, which was missing for the concrete simulator documentation page.