### PR TITLE
Removed misplaced backslash from identifier regex

### DIFF
--- a/content/language-reference/expressions/identifiers.md
+++ b/content/language-reference/expressions/identifiers.md
@@ -3,7 +3,7 @@ title: Identifiers
 weight: 10
 ---
 
-The valid identifier names are described by the following regular expression: `[a-zA-Z_]\([a-zA-Z0-9_])*`
+The valid identifier names are described by the following regular expression: `[a-zA-Z_]([a-zA-Z0-9_])*`
 
 ## Examples
 


### PR DESCRIPTION
Removed misplaced backslash from identifier regex